### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/112/582/107/5/1125821075.geojson
+++ b/data/112/582/107/5/1125821075.geojson
@@ -267,6 +267,9 @@
     },
     "wof:country":"GG",
     "wof:created":1497292068,
+    "wof:geom_alt":[
+        "qs_pg"
+    ],
     "wof:geomhash":"c803a38285c62bf588344a85d60c238a",
     "wof:hierarchy":[
         {
@@ -278,7 +281,7 @@
         }
     ],
     "wof:id":1125821075,
-    "wof:lastmodified":1568146869,
+    "wof:lastmodified":1582346824,
     "wof:name":"Saint Peter Port",
     "wof:parent_id":1477797913,
     "wof:placetype":"locality",

--- a/data/856/325/47/85632547.geojson
+++ b/data/856/325/47/85632547.geojson
@@ -634,6 +634,10 @@
     },
     "wof:country":"GG",
     "wof:country_alpha3":"GGY",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"56abb7361d23a6c2dee78350067616fa",
     "wof:hierarchy":[
         {
@@ -649,7 +653,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566637483,
+    "wof:lastmodified":1582346824,
     "wof:name":"Guernsey",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.