### PR TITLE
Name updates

### DIFF
--- a/data/112/580/539/1/1125805391.geojson
+++ b/data/112/580/539/1/1125805391.geojson
@@ -72,7 +72,7 @@
         "\u0633\u06cc\u0646\u0679 \u0633\u0645\u067e\u0633\u0648\u06ba \u060c \u06af\u0631\u0646\u0632\u06cc"
     ],
     "name:urd_x_variant":[
-        "\u0633\u06cc\u0646\u0679 \u0633\u0645\u067e\u0633\u0648\u06ba "
+        "\u0633\u06cc\u0646\u0679 \u0633\u0645\u067e\u0633\u0648\u06ba"
     ],
     "qs_pg:aaroncc":"GG",
     "qs_pg:gn_country":"GG",
@@ -126,7 +126,7 @@
         }
     ],
     "wof:id":1125805391,
-    "wof:lastmodified":1568146871,
+    "wof:lastmodified":1587163113,
     "wof:name":"St. Sampson",
     "wof:parent_id":1477797913,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.