### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/580/539/1/1125805391.geojson
+++ b/data/112/580/539/1/1125805391.geojson
@@ -62,8 +62,17 @@
     "name:pol_x_preferred":[
         "St Sampson's"
     ],
+    "name:pol_x_variant":[
+        "St Sampson\u2019s"
+    ],
     "name:por_x_preferred":[
         "Saint Sampson"
+    ],
+    "name:rus_x_preferred":[
+        "\u0421\u0435\u043d\u0442-\u0421\u0430\u043c\u043f\u0441\u043e\u043d"
+    ],
+    "name:spa_x_preferred":[
+        "Saint Samsaon"
     ],
     "name:swe_x_preferred":[
         "Saint Sampson"
@@ -72,7 +81,11 @@
         "\u0633\u06cc\u0646\u0679 \u0633\u0645\u067e\u0633\u0648\u06ba \u060c \u06af\u0631\u0646\u0632\u06cc"
     ],
     "name:urd_x_variant":[
-        "\u0633\u06cc\u0646\u0679 \u0633\u0645\u067e\u0633\u0648\u06ba"
+        "\u0633\u06cc\u0646\u0679 \u0633\u0645\u067e\u0633\u0648\u06ba",
+        "\u0633\u06cc\u0646\u0679 \u0633\u0645\u067e\u0633\u0648\u06ba "
+    ],
+    "name:zho_x_preferred":[
+        "\u8056\u6851\u666e\u68ee"
     ],
     "qs_pg:aaroncc":"GG",
     "qs_pg:gn_country":"GG",
@@ -126,7 +139,7 @@
         }
     ],
     "wof:id":1125805391,
-    "wof:lastmodified":1587163113,
+    "wof:lastmodified":1690921639,
     "wof:name":"St. Sampson",
     "wof:parent_id":1477797913,
     "wof:placetype":"locality",

--- a/data/112/582/107/5/1125821075.geojson
+++ b/data/112/582/107/5/1125821075.geojson
@@ -28,14 +28,23 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646 \u0628\u064a\u062a\u0631 \u0628\u0648\u0631\u062a"
     ],
+    "name:arg_x_preferred":[
+        "Saint Pierre Port"
+    ],
     "name:ast_x_preferred":[
         "Saint Peter Port"
+    ],
+    "name:ast_x_variant":[
+        "Puertu San Pedru"
     ],
     "name:aze_x_preferred":[
         "Sent Piter Port"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u0435\u043d\u0442-\u041f\u0456\u0442\u044d\u0440-\u041f\u043e\u0440\u0442"
+    ],
+    "name:bel_x_variant":[
+        "\u0421\u0435\u043d\u0442-\u041f\u0456\u0442\u044d\u0440-\u041f\u043e\u0440\u0442"
     ],
     "name:bre_x_preferred":[
         "Saint Pierre Port"
@@ -67,6 +76,9 @@
     "name:deu_x_preferred":[
         "Saint Peter Port"
     ],
+    "name:diq_x_preferred":[
+        "St. Peter Port"
+    ],
     "name:ell_x_preferred":[
         "\u03a3\u03b5\u03bd\u03c4 \u03a0\u03af\u03c4\u03b5\u03c1 \u03a0\u03bf\u03c1\u03c4"
     ],
@@ -97,11 +109,17 @@
     "name:gla_x_preferred":[
         "St. Peter Port"
     ],
+    "name:gle_x_preferred":[
+        "Saint Peter Port"
+    ],
     "name:glg_x_preferred":[
         "Saint Peter Port"
     ],
     "name:heb_x_preferred":[
         "\u05e1\u05e0\u05d8 \u05e4\u05d9\u05d8\u05e8 \u05e4\u05d5\u05e8\u05d8"
+    ],
+    "name:hin_x_preferred":[
+        "\u0938\u0947\u0902\u091f \u092a\u0940\u091f\u0930 \u092a\u094b\u0930\u094d\u091f"
     ],
     "name:hrv_x_preferred":[
         "St. Peter Port"
@@ -116,6 +134,9 @@
         "Saint Peter Port"
     ],
     "name:ind_x_preferred":[
+        "Saint Peter Port"
+    ],
+    "name:isl_x_preferred":[
         "Saint Peter Port"
     ],
     "name:ita_x_preferred":[
@@ -151,6 +172,9 @@
     "name:mri_x_preferred":[
         "St Peter Port"
     ],
+    "name:mzn_x_preferred":[
+        "\u0633\u0646\u062a \u067e\u062a\u0631 \u067e\u0648\u0631\u062a"
+    ],
     "name:nan_x_preferred":[
         "Saint Peter Port"
     ],
@@ -165,6 +189,9 @@
     ],
     "name:nob_x_preferred":[
         "St Peter Port"
+    ],
+    "name:nob_x_variant":[
+        "Saint Peter Port"
     ],
     "name:nor_x_preferred":[
         "St Peter Port"
@@ -232,6 +259,9 @@
     "name:war_x_preferred":[
         "St. Peter Port"
     ],
+    "name:wuu_x_preferred":[
+        "\u5723\u5f7c\u5f97\u6e2f"
+    ],
     "name:zho_x_preferred":[
         "\u5723\u5f7c\u5f97\u6e2f"
     ],
@@ -283,7 +313,7 @@
         }
     ],
     "wof:id":1125821075,
-    "wof:lastmodified":1607390892,
+    "wof:lastmodified":1690921640,
     "wof:name":"Saint Peter Port",
     "wof:parent_id":1477797913,
     "wof:placetype":"locality",

--- a/data/112/590/743/1/1125907431.geojson
+++ b/data/112/590/743/1/1125907431.geojson
@@ -79,6 +79,9 @@
     "name:und_x_variant":[
         "Torteval Church"
     ],
+    "name:zho_x_preferred":[
+        "\u6258\u7279\u74e6\u723e"
+    ],
     "qs_pg:aaroncc":"GG",
     "qs_pg:gn_country":"GG",
     "qs_pg:gn_fcode":"PPL",
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":1125907431,
-    "wof:lastmodified":1568146873,
+    "wof:lastmodified":1690921639,
     "wof:name":"Torteval",
     "wof:parent_id":1477797913,
     "wof:placetype":"locality",

--- a/data/147/779/791/5/1477797915.geojson
+++ b/data/147/779/791/5/1477797915.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0631\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0631\u0643"
+    ],
     "name:bak_x_preferred":[
         "\u0421\u0430\u0440\u043a"
     ],
@@ -200,6 +203,9 @@
     "name:slv_x_preferred":[
         "Sark"
     ],
+    "name:snd_x_preferred":[
+        "\u0633\u0627\u0631\u06aa"
+    ],
     "name:spa_x_preferred":[
         "Sark"
     ],
@@ -235,6 +241,12 @@
     ],
     "name:vls_x_preferred":[
         "Sark"
+    ],
+    "name:war_x_preferred":[
+        "Sark"
+    ],
+    "name:wuu_x_preferred":[
+        "\u8428\u514b\u5c9b"
     ],
     "name:zho_cn_x_preferred":[
         "\u8428\u514b\u5c9b"
@@ -345,7 +357,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501284,
+    "wof:lastmodified":1690921640,
     "wof:name":"Sark",
     "wof:parent_id":85632547,
     "wof:placetype":"region",

--- a/data/856/325/47/85632547.geojson
+++ b/data/856/325/47/85632547.geojson
@@ -42,11 +42,17 @@
     "name:ang_x_preferred":[
         "Guernsey"
     ],
+    "name:anp_x_preferred":[
+        "\u0917\u0941\u090f\u0928\u0930\u094d\u0938\u0947"
+    ],
     "name:ara_x_preferred":[
         "\u063a\u064a\u0631\u0646\u0632\u064a"
     ],
     "name:arg_x_preferred":[
         "Guern\u00e9si"
+    ],
+    "name:arz_x_preferred":[
+        "\u062c\u064a\u0631\u0646\u0632\u0649"
     ],
     "name:ast_x_preferred":[
         "Guernsey"
@@ -71,6 +77,9 @@
     ],
     "name:ben_x_preferred":[
         "\u0997\u09cd\u09b0\u09be\u099e\u09cd\u099c\u09bf"
+    ],
+    "name:ben_x_variant":[
+        "\u0997\u09be\u09b0\u09cd\u09a8\u09b8\u09bf"
     ],
     "name:bos_x_preferred":[
         "Guernsey"
@@ -121,6 +130,9 @@
     "name:deu_x_preferred":[
         "Guernsey"
     ],
+    "name:diq_x_preferred":[
+        "Guernsey"
+    ],
     "name:div_x_preferred":[
         "\u078e\u07aa\u0787\u07a7\u0782\u07b0\u0790\u07ad"
     ],
@@ -128,7 +140,8 @@
         "\u0393\u03ba\u03ad\u03c1\u03bd\u03c3\u03b5\u03ca"
     ],
     "name:ell_x_variant":[
-        "\u0393\u03ba\u03b5\u03c1\u03bd\u03c3\u03ad\u03b9"
+        "\u0393\u03ba\u03b5\u03c1\u03bd\u03c3\u03ad\u03b9",
+        "\u0393\u03ba\u03ad\u03c1\u03bd\u03b6\u03b9"
     ],
     "name:eng_x_preferred":[
         "Guernsey"
@@ -193,6 +206,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0a97\u0acd\u0ab5\u0ac7\u0ab0\u0acd\u0aa8\u0ab8\u0ac7"
+    ],
+    "name:hak_x_preferred":[
+        "Guernsey"
     ],
     "name:hau_x_preferred":[
         "Guernsey"
@@ -269,6 +285,9 @@
     "name:kin_x_preferred":[
         "Gwasi"
     ],
+    "name:kir_x_preferred":[
+        "\u0413\u0435\u0440\u043d\u0441\u0438"
+    ],
     "name:kor_x_preferred":[
         "\uac74\uc9c0"
     ],
@@ -281,6 +300,9 @@
     ],
     "name:lat_x_preferred":[
         "Lisia"
+    ],
+    "name:lat_x_variant":[
+        "Sarnia insula"
     ],
     "name:lav_x_preferred":[
         "G\u0113rnsija"
@@ -320,6 +342,9 @@
     ],
     "name:mar_x_variant":[
         "\u0917\u094d\u0935\u0947\u0930\u094d\u0928\u0938\u0947"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0413\u044d\u0440\u043d\u0441\u0438"
     ],
     "name:mkd_x_preferred":[
         "\u0413\u0435\u0440\u043d\u0437\u0438"
@@ -424,7 +449,8 @@
         "\u0413\u0435\u0440\u043d\u0437\u0438"
     ],
     "name:srp_x_variant":[
-        "\u0413\u0443\u0440\u043d\u0441\u0438"
+        "\u0413\u0443\u0440\u043d\u0441\u0438",
+        "\u0411\u0435\u0458\u043b\u0438\u0432\u0438\u043a \u0413\u0435\u0440\u043d\u0437\u0438"
     ],
     "name:sun_x_preferred":[
         "Guernsey"
@@ -476,6 +502,9 @@
     ],
     "name:urd_x_variant":[
         "\u06af\u0648\u0626\u0631\u0646\u0633\u06cc"
+    ],
+    "name:uzb_x_preferred":[
+        "Gernsi"
     ],
     "name:vie_x_preferred":[
         "Guernsey"
@@ -718,7 +747,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636501281,
+    "wof:lastmodified":1690921638,
     "wof:name":"Guernsey",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.