### PR TITLE
gg concordances, placetype local, and more

### DIFF
--- a/data/147/779/791/3/1477797913.geojson
+++ b/data/147/779/791/3/1477797913.geojson
@@ -536,7 +536,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694493259,
+    "wof:lastmodified":1695884881,
     "wof:name":"Guernsey",
     "wof:parent_id":85632547,
     "wof:placetype":"region",

--- a/data/147/779/791/5/1477797915.geojson
+++ b/data/147/779/791/5/1477797915.geojson
@@ -363,7 +363,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694493259,
+    "wof:lastmodified":1695884881,
     "wof:name":"Sark",
     "wof:parent_id":85632547,
     "wof:placetype":"region",

--- a/data/147/779/791/9/1477797919.geojson
+++ b/data/147/779/791/9/1477797919.geojson
@@ -62,7 +62,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694493259,
+    "wof:lastmodified":1695884881,
     "wof:name":"Alderney",
     "wof:parent_id":85632547,
     "wof:placetype":"region",

--- a/data/856/325/47/85632547.geojson
+++ b/data/856/325/47/85632547.geojson
@@ -721,6 +721,7 @@
         "gn:id":3042362,
         "gp:id":23424827,
         "hasc:id":"GG",
+        "iso:code":"GG",
         "m49:code":"831",
         "marc:id":"uik",
         "mzb:id":"guernsey",
@@ -730,6 +731,7 @@
         "uncrt:id":"GBG",
         "wd:id":"Q25230"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GG",
     "wof:country_alpha3":"GGY",
     "wof:geom_alt":[
@@ -751,7 +753,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639668,
+    "wof:lastmodified":1695881328,
     "wof:name":"Guernsey",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.